### PR TITLE
Add Dockerfile and container build workflow

### DIFF
--- a/.github/workflows/build-container.yaml
+++ b/.github/workflows/build-container.yaml
@@ -1,0 +1,31 @@
+name: Build Container
+
+"on":
+  push:
+    branches:
+      - main
+    tags:
+      - "v[0-9]+.[0-9]+.[0-9]+"
+jobs:
+  docker:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+      - name: Login to GHCR
+        uses: docker/login-action@v2
+        if: github.event_name != 'pull_request'
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Build and push
+        id: docker_build
+        uses: docker/build-push-action@v4
+        with:
+          push: true
+          tags: |
+            ghcr.io/${{ github.repository_owner }}/mastodon_get_replies:${{ github.ref_name }}
+            ghcr.io/${{ github.repository_owner }}/mastodon_get_replies:latest

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,6 @@
+FROM python:3.11-alpine
+WORKDIR /app
+COPY ./requirements.txt /app/requirements.txt
+RUN pip install --no-cache-dir --upgrade -r /app/requirements.txt
+COPY ./find_posts.py /app/
+ENTRYPOINT ["python", "find_posts.py"]

--- a/README.md
+++ b/README.md
@@ -63,6 +63,17 @@ When setting up your cronjob, do make sure you are setting the interval long eno
 
 If you are running this script locally, my recommendation is to run it manually once, before turning on the cron job: The first run will be significantly slower than subsequent runs, and that will help you prevent overlapping during that first run.
 
+### 4) Run this script from a container
+
+This script is also available in a pre-packaged container, [mastodon_get_replies](https://github.com/nanos/mastodon_get_replies/pkgs/container/mastodon_get_replies).
+
+1. Pull the container from `ghcr.io`, using Docker or your container tool of choice: `docker pull ghcr.io/nanos/mastodon_get_replies:latest`
+2. Run the container, passing the command line arguments like running the script directly: `docker run -it ghcr.io/nanos/mastodon_get_replies:latest --access-token=<TOKEN> --server=<SERVER>`
+
+The same rules for running this as a cron job apply to running the container, don't overlap any executions.
+
+An example Kubernetes CronJob for running the container is included in the [`examples`](https://github.com/nanos/mastodon_get_replies/tree/main/examples) folder.
+
 ## Acknowledgments
 
 This script is mostly taken from [Abhinav Sarkar](https://notes.abhinavsarkar.net/2023/mastodon-context), with just some additions and alterations. Thank you Abhinav!

--- a/examples/k8s-cronjob.yaml
+++ b/examples/k8s-cronjob.yaml
@@ -1,0 +1,23 @@
+---
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: mastodon-get-replies
+spec:
+  # Run every 2 hours
+  schedule: "0 */2 * * *"
+  successfulJobsHistoryLimit: 1
+  failedJobsHistoryLimit: 1
+  concurrencyPolicy: Forbid
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          containers:
+            - name: mastodon-get-replies
+              image: ghcr.io/nanos/mastodon_get_replies:latest
+              args:
+                - --server=your.server.social
+                - --access-token=TOKEN
+          restartPolicy: Never
+


### PR DESCRIPTION
I'm in the process of setting up this script to run within my Kubernetes Mastodon instance and needed it packaging up for ease of use. So I thought I'd contribute back the changes.

This adds the following

* Dockerfile to generate the container
* A new Github workflow to build and publish the container on ghcr.io 

The script is provided as a entry point, so the container can be used with `docker run containername --server=mastodon.social ...`.