### PR TITLE
Update Kubernetes example and README for persistence

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,8 @@ This script is also available in a pre-packaged container, [mastodon_get_replies
 
 The same rules for running this as a cron job apply to running the container, don't overlap any executions.
 
+Persistent files are stored in `/app/artifacts` within the container, so you may want to map this to a local folder on your system.
+
 An example Kubernetes CronJob for running the container is included in the [`examples`](https://github.com/nanos/mastodon_get_replies/tree/main/examples) folder.
 
 ## Acknowledgments

--- a/examples/k8s-cronjob.yaml
+++ b/examples/k8s-cronjob.yaml
@@ -35,6 +35,14 @@ spec:
               args:
                 - --server=your.server.social
                 - --access-token=TOKEN
+                - --home-timeline-length
+                - "200"
+                - --reply-interval-in-hours
+                - "24"
+                - --max-followings
+                - "80"
+                - --max-followers
+                - "80"
               volumeMounts:
                 - name: artifacts
                   mountPath: /app/artifacts

--- a/examples/k8s-cronjob.yaml
+++ b/examples/k8s-cronjob.yaml
@@ -1,4 +1,16 @@
 ---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: mastodon-get-replies-pvc
+spec:
+  accessModes:
+    - ReadWriteOnce
+  volumeMode: Filesystem
+  resources:
+    requests:
+      storage: 100Mi
+---
 apiVersion: batch/v1
 kind: CronJob
 metadata:
@@ -13,11 +25,17 @@ spec:
     spec:
       template:
         spec:
+          volumes:
+            - name: artifacts
+              persistentVolumeClaim:
+                claimName: mastodon-get-replies-pvc
           containers:
             - name: mastodon-get-replies
               image: ghcr.io/nanos/mastodon_get_replies:latest
               args:
                 - --server=your.server.social
                 - --access-token=TOKEN
+              volumeMounts:
+                - name: artifacts
+                  mountPath: /app/artifacts
           restartPolicy: Never
-


### PR DESCRIPTION
I missed out some notes and examples of storing the persistent files in `artifacts`. This is a quick update for the README and examples.