### PR TITLE
Create artifacts directory in docker image

### DIFF
--- a/.github/workflows/get_context.yml
+++ b/.github/workflows/get_context.yml
@@ -39,5 +39,5 @@ jobs:
           name: artifacts
           path: |
             artifacts
-      - name: Keep workflow alive
-        uses: gautamkrishnar/keepalive-workflow@v1
+#       - name: Keep workflow alive
+#         uses: gautamkrishnar/keepalive-workflow@v1

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,5 +2,6 @@ FROM python:3.11-alpine
 WORKDIR /app
 COPY ./requirements.txt /app/requirements.txt
 RUN pip install --no-cache-dir --upgrade -r /app/requirements.txt
+RUN mkdir -p /app/artifacts/
 COPY ./find_posts.py /app/
 ENTRYPOINT ["python", "find_posts.py"]


### PR DESCRIPTION
The `/app/artifacts/` directory is required for storing the lock file. The current Dockerfile was created prior to this feature being added in 62989f4041d2547718d8625e1c3588cf4bdaadee and now fails when being run.

![image](https://user-images.githubusercontent.com/867617/226765448-32f77ace-009d-4b7b-b55c-d23c5790758c.png)

This pull request creates that directory in the Docker image.